### PR TITLE
feat: add rush.json

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -193,6 +193,7 @@ const full = {
   '.env': stringify(env),
   'dockerfile': stringify(docker),
   'package.json': stringify(packageJSON),
+  'rush.json': stringify(packageJSON),
   'readme.md': stringify(readme),
   'cargo.toml': stringify(cargo),
   'gemfile': stringify(gemfile),


### PR DESCRIPTION
[Rush](https://rushjs.io/)'s monorepo doesn't have package.json