### PR TITLE
Add trailing comma

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -213,7 +213,7 @@ fs.writeFileSync('README.md',
   // https://github.com/antfu/vscode-file-nesting-config
   "explorer.experimental.fileNesting.enabled": true,
   "explorer.experimental.fileNesting.expand": false,
-  "explorer.experimental.fileNesting.patterns": ${body.trimStart()}
+  "explorer.experimental.fileNesting.patterns": ${body.trimStart()},
 \`\`\``.trim()
     })
   ,


### PR DESCRIPTION
VSCode's `settings.json` supports trailing comma, adding it to make it easier to drop the config anywhere.