### PR TITLE
Add Nix files

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -182,6 +182,8 @@ const base = {
   'index.d.ts': '*.d.ts',
   'shims.d.ts': '*.d.ts',
   'go.mod': 'go.sum',
+  'default.nix': 'shell.nix',
+  'flake.nix': 'flake.lock',
 }
 
 function stringify(items) {
@@ -198,8 +200,6 @@ const full = {
   'cargo.toml': stringify(cargo),
   'gemfile': stringify(gemfile),
   'go.mod': stringify(gofile),
-  'default.nix': 'shell.nix',
-  'flake.nix': 'flake.lock',
   ...Object.fromEntries(Object.entries(frameworks).map(([n, i]) => [n, stringify([...i, ...libraries])])),
 }
 

--- a/update.mjs
+++ b/update.mjs
@@ -198,6 +198,8 @@ const full = {
   'cargo.toml': stringify(cargo),
   'gemfile': stringify(gemfile),
   'go.mod': stringify(gofile),
+  'default.nix': 'shell.nix',
+  'flake.nix': 'flake.lock',
   ...Object.fromEntries(Object.entries(frameworks).map(([n, i]) => [n, stringify([...i, ...libraries])])),
 }
 


### PR DESCRIPTION
This PR adds two folding rules useful to [Nix](https://nixos.org/guides/how-nix-works.html) package manager. I hope you don't find this too niche :)

- [`default.nix`](https://nixos.org/manual/nix/stable/command-ref/nix-build.html?highlight=default.nix#description) is like `webpack.config.js` that describes how a package should build, and is used by `nix build` command by default.
  [`shell.nix`](https://nixos.org/manual/nix/stable/command-ref/nix-shell.html?highlight=shell.nix#description) commonly accompanies `default.nix` and `nix shell`, the main command that consumes it, uses `default.nix` as a fallback. Thus these two files have strong relationship.
- `flake.nix` and [`flake.lock`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#lock-files) are just like `package.json` and `package-lock.json`

For a real world project using these files see [the repo for NixOS homepage](https://github.com/NixOS/nixos-homepage).