### PR TITLE
Support more readme files, not just Markdown

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -145,7 +145,7 @@ const readme = [
   'authors',
   'code_of_conduct.md',
   'contributing.md',
-  'changelog*.md',
+  'changelog*',
   'backers.md',
   'sponsors.md',
   'security.md',
@@ -155,6 +155,7 @@ const readme = [
   'contributors',
   'maintainers',
   'credits',
+  'citation*'
 ]
 
 const cargo = [
@@ -194,7 +195,7 @@ const full = {
   'dockerfile': stringify(docker),
   'package.json': stringify(packageJSON),
   'rush.json': stringify(packageJSON),
-  'readme.md': stringify(readme),
+  'readme.*': stringify(readme),
   'cargo.toml': stringify(cargo),
   'gemfile': stringify(gemfile),
   'go.mod': stringify(gofile),


### PR DESCRIPTION
While Markdown being the dominant markup format, some people still prefer other formats and it makes sense to support those as well.

This PR made two changes:

- Match `readme.*` instead of only `readme.md`, `changelog*` instead of only `changelog*.md`: as can be seen in real world projects like [kitty](https://github.com/kovidgoyal/kitty)

  I did not go change all `.md` patterns to `.*` because readme and changelog are the far more common and some platform-specific (namely GitHub) files (e.g. `contributing.md`) is only considered valid if they have the `.md` extension.

- Add [CITATION files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files): as can be seen in real world projects like [Zettlr](https://github.com/Zettlr/Zettlr/blob/37022e785db6ff3a4347cf2e791e2274078a02a3/CITATION.cff)