### PR TITLE
chore: improve lint-staged config

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -62,6 +62,7 @@ const linters = [
   'dangerfile*',
   'dprint.json',
   'lint-staged*',
+  '.lintstagedrc*',
   'prettier*',
   'stylelint*',
   'tslint*',


### PR DESCRIPTION
It improves the lint-staged config (for PR #2) because it can use the `.lintstagedrc.*` [filename syntax](https://github.com/okonet/lint-staged#configuration).
