### PR TITLE
For niche project all config.js go under package.json

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -136,6 +136,7 @@ const packageJSON = [
   '.pm2*',
   '.vscode*',
   '.watchman*',
+  '*config.js',
   'nest-cli.*',
   'nodemon*',
   'pm2.*',


### PR DESCRIPTION
Not sure if this is an edge case.
My working [repo ](https://github.com/vanilla/vanilla) is a popular forum using their own php framework called: "garden".
In the repo, `babel.config.js` `jest.eslint.config.js` are not included in `package.json`

For framework, it has no vue/react config at / folder, so  `babel.config.*` will not apply.
For `jest.eslint.config.js`, packageJSON rule: `jest.config.*` will not apply.

## Workaround
> info:  vscode duplicate file that matches multiple rules  

So, maybe we can make the rest of *config.json(for outdated/niche usage) under package.json without refactoring framework rules.

![image](https://user-images.githubusercontent.com/24861096/157373448-b6416ee3-5c5a-4fcd-8042-f1d0a727cc16.png)
