### PR TITLE
chore: extend Rust config file list

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -178,6 +178,10 @@ const cargo = [
   'cargo.lock',
   'rust-toolchain.toml',
   'rustfmt.toml',
+  '.rustfmt.toml',
+  'clippy.toml',
+  '.clippy.toml',
+  'cross.toml'
 ]
 
 const gofile = [


### PR DESCRIPTION
Heya Anthony! 👋 

This is a quick PR to extend the Rust config files that are listed:
- **.rustfmt.toml** – Both `rustfmt.toml` and `clippy.toml` are valid and recognized if prefixed with a `.`
- **.clippy.toml / clippy.toml** – Configuration file for [clippy](https://github.com/rust-lang/rust-clippy), the linter typically used for Rust projects
- **cross.toml** – Configuration for [cross](https://github.com/cross-rs/cross), a common cross-compilation and testing tool

Keep up the good work! 😄 