### PR TITLE
Add mdsvex.config.js to Svelte

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -110,7 +110,7 @@ const frameworks = {
   'vue.config.*': [],
   'nuxt.config.*': [],
   'next.config.*': ['next-env.d.ts'],
-  'svelte.config.*': [],
+  'svelte.config.*': ['mdsvex.config.js'],
   'remix.config.*': ['remix.*'],
 }
 


### PR DESCRIPTION
[mdsvex](https://mdsvex.com) is the de-facto markdown library for Svelte, and thus very common in Svelte/Sveltekit projects.