### PR TITLE
Captured more variants of docker-compose and its sub-files

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -103,7 +103,7 @@ const workspaces = [
 const docker = [
   'dockerfile*',
   '.dockerignore',
-  'docker-compose.yml',
+  'docker-compose.*'
 ]
 
 // frameworks and their specific files


### PR DESCRIPTION
I've tweaked the `docker` entries to ensure we capture more variants of the `docker-compose` file and subfiles.

This way it would cover:
- `docker-compose.yml`
- `docker-compose.dev.yml`
- `docker-compose.env`

And so-on and so forth.

Happy to take on feedback if there's a better way of doing this :)