### PR TITLE
Add support for Quasar Framework

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -117,6 +117,7 @@ const frameworks = {
   'artisan': ['server.php', 'webpack.mix.js'],
   'astro.config.*': [],
   'gatsby-config.*': ['gatsby-browser.*', 'gatsby-node.*', 'gatsby-ssr.*', 'gatsby-transformer.*'],
+  'quasar.conf.js': ['quasar.extensions.json']
 }
 
 // library configs, will be appended to all the frameworks


### PR DESCRIPTION
Quasar Framework (https://github.com/quasarframework/quasar) provides a framework for building web and hybrid apps on top of VueJs. This PR adds support for grouping it's config files.