### PR TITLE
fix: better tsx file capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Open your VS Code, bring up your `settings.json`, copy-n-paste the snippet below
     "*.pubxml": "$(capture).pubxml.user",
     "*.resx": "$(capture).*.resx, $(capture).designer.cs, $(capture).designer.vb",
     "*.ts": "$(capture).js, $(capture).*.ts",
-    "*.tsx": "$(capture).ts",
+    "*.tsx": "$(capture).ts, $(capture).*.tsx",
     "*.vbproj": "*.config, *proj.user, appsettings.*, bundleconfig.json",
     "*.vue": "$(capture).*.ts, $(capture).*.js",
     ".clang-tidy": ".clang-format",

--- a/update.mjs
+++ b/update.mjs
@@ -242,7 +242,7 @@ const base = {
   '*.js': '$(capture).js.map, $(capture).min.js, $(capture).d.ts',
   '*.jsx': '$(capture).js',
   '*.ts': '$(capture).js, $(capture).*.ts',
-  '*.tsx': '$(capture).ts',
+  '*.tsx': '$(capture).ts, $(capture).*.tsx',
   '*.vue': '$(capture).*.ts, $(capture).*.js',
   'index.d.ts': '*.d.ts',
   'shims.d.ts': '*.d.ts',


### PR DESCRIPTION
# Context

fix https://github.com/antfu/vscode-file-nesting-config/issues/70

# Changes

This PR updates the rules to include `$(capture).*.tsx` inside `*.tsx` so that files like `MyFile.test.tsx` becomes child of `MyFile.tsx`