### PR TITLE
feat: remove experimental flag

### DIFF
--- a/extension/src/fetch.ts
+++ b/extension/src/fetch.ts
@@ -21,7 +21,7 @@ export async function fetchLatest() {
   }}`
 
   const config = JSON.parse(json) || {}
-  return config['explorer.experimental.fileNesting.patterns']
+  return config['explorer.fileNesting.patterns']
 }
 
 export async function fetchAndUpdate(ctx: ExtensionContext, prompt = true) {
@@ -41,10 +41,10 @@ export async function fetchAndUpdate(ctx: ExtensionContext, prompt = true) {
 
   if (shouldUpdate) {
     const config = workspace.getConfiguration()
-    config.update('explorer.experimental.fileNesting.enabled', true, true)
-    if (config.inspect('explorer.experimental.fileNesting.expand').globalValue == null)
-      config.update('explorer.experimental.fileNesting.expand', false, true)
-    config.update('explorer.experimental.fileNesting.patterns', {
+    config.update('explorer.fileNesting.enabled', true, true)
+    if (config.inspect('explorer.fileNesting.expand').globalValue == null)
+      config.update('explorer.fileNesting.expand', false, true)
+    config.update('explorer.fileNesting.patterns', {
       '//': `Last update at ${new Date().toLocaleString()}`,
       ...patterns,
     }, true)

--- a/update.mjs
+++ b/update.mjs
@@ -354,9 +354,9 @@ fs.writeFileSync('README.md',
 \`\`\`jsonc
   // updated ${today}
   // https://github.com/antfu/vscode-file-nesting-config
-  "explorer.experimental.fileNesting.enabled": true,
-  "explorer.experimental.fileNesting.expand": false,
-  "explorer.experimental.fileNesting.patterns": ${body.trimStart()},
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": ${body.trimStart()},
 \`\`\``.trim()
     })
   ,


### PR DESCRIPTION
The current update of vscode has moved the experimental flag from the settings used in the script

![](https://i.imgur.com/GKZd0L4.png)

Now:

![](https://i.imgur.com/JA40u2o.png)
