### PR TITLE
fix: apply non-experimental config

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -354,6 +354,9 @@ fs.writeFileSync('README.md',
 \`\`\`jsonc
   // updated ${today}
   // https://github.com/antfu/vscode-file-nesting-config
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": ${body.trimStart()},
   "explorer.experimental.fileNesting.enabled": true,
   "explorer.experimental.fileNesting.expand": false,
   "explorer.experimental.fileNesting.patterns": ${body.trimStart()},


### PR DESCRIPTION
vs code is about to take file nesting out of experimental status, based on what i'm seeing in nightlies

this gets nesting working for the nightly users, and ensures beta+stable users will still have nesting when the update rolls out