### PR TITLE
feat: add `release-tasks.sh`

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -46,6 +46,7 @@ const services = [
   'netlify*',
   'Procfile',
   'pullapprove*',
+  'release-tasks.sh',
   'renovate*',
   'vercel*',
   '.firebase*',


### PR DESCRIPTION
heroku softly recommends using `release-tasks.sh` when a release phase needs multiple commands

see [heroku doc](https://devcenter.heroku.com/articles/release-phase#specifying-release-phase-tasks)