### PR TITLE
C# partial class and interface/implementation nesting

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -322,6 +322,8 @@ const base = {
   '*.master': '$(capture).*.cs, $(capture).*.vb',
   '*.xaml': '$(capture).xaml.cs',
   '*.cshtml': '$(capture).cshtml.cs',
+  '*.cs': '$(capture).*.cs',
+  'I*.cs': '$(capture).cs',
   '*.resx': '$(capture).*.resx, $(capture).designer.cs, $(capture).designer.vb',
   '*.dart': '$(capture).freezed.dart, $(capture).g.dart',
   '*.bloc.dart': '$(capture).event.dart, $(capture).state.dart',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

1. `'*.cs': '$(capture).*.cs'` -  nests partial classes.  If you have `Authentication.cs`, `Authentication.Login.cs` and `Authentication.Register.cs` files, then two child files get nested under `Authentication.cs`.

2. `'I*.cs': '$(capture).cs'` - nests C# implementation under its interface. If you have `IStudentService` and `StudentService`, then `StudentService` gets nested under `IStudentService`>

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
