### PR TITLE
feat: add support for new SvelteKit's routing system convention

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -334,6 +334,11 @@ const base = {
   '*.java': '$(capture).class',
   '.project': '.classpath',
 }
+// Based on the new SvelteKit's routing system https://kit.svelte.dev/docs/routing
+const svelteKitRouting = {
+  '+page.svelte': '+page.server.ts,+page.server.js,+page.ts,+page.js ',
+  '+layout.svelte':'+layout.ts,+layout.ts,+layout.js,+layout.server.ts,+layout.server.js'   
+}
 
 function stringify(items) {
   return Array.from(new Set(items)).sort().join(', ')
@@ -366,6 +371,7 @@ const full = sortObject({
   '*.tex': stringify(tex),
   "deno.json*": stringify(denoRuntime),
   ...Object.fromEntries(Object.entries(frameworks).map(([n, i]) => [n, stringify([...i, ...libraries])])),
+  ...svelteKitRouting
 })
 
 const today = new Date().toISOString().slice(0, 16).replace('T', ' ')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Add support for the new SvelteKit's routing system naming convention found in the [official documentation](https://kit.svelte.dev/docs/routing).

It will nest files like this
- `+page.svelte``
    - `+page.js`
    - `+page.server.js` 
- `+layout.svelte`
    - `+layout.js`
    - `+layout.server.js`
    
  
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

