### PR TITLE
removed tsconfig from package.json

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -180,7 +180,6 @@ const libraries = [
   'windi.config.*',
   ...env,
   ...testingTools,
-  ...tsconfig,
 ]
 
 const packageJSON = [

--- a/update.mjs
+++ b/update.mjs
@@ -180,6 +180,7 @@ const libraries = [
   'windi.config.*',
   ...env,
   ...testingTools,
+  ...tsconfig,
 ]
 
 const packageJSON = [
@@ -201,7 +202,6 @@ const packageJSON = [
   ...buildTools,
   ...services,
   ...linters,
-  ...tsconfig,
   ...testingTools,
 ]
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

There seems to be a repetition of the `tsconfig.json` file when using frameworks. I have removed `...tsconfig` from the libraries array to avoid repetition because all projects already contain a `package.json` (tsconfig is already nested under it).

### Linked Issues

This seems to have occurred in the following issues: https://github.com/antfu/vscode-file-nesting-config/issues/135 and https://github.com/antfu/vscode-file-nesting-config/issues/94

<!-- e.g. is there anything you'd like reviewers to focus on? -->
