### PR TITLE
fix: avoid force enabling explorer fileNesting config

### DIFF
--- a/extension/src/fetch.ts
+++ b/extension/src/fetch.ts
@@ -41,9 +41,13 @@ export async function fetchAndUpdate(ctx: ExtensionContext, prompt = true) {
 
   if (shouldUpdate) {
     const config = workspace.getConfiguration()
-    config.update('explorer.fileNesting.enabled', true, true)
+
+    if (config.inspect('explorer.fileNesting.enabled').globalValue == null)
+      config.update('explorer.fileNesting.enabled', true, true)
+
     if (config.inspect('explorer.fileNesting.expand').globalValue == null)
       config.update('explorer.fileNesting.expand', false, true)
+    
     config.update('explorer.fileNesting.patterns', {
       '//': `Last update at ${new Date().toLocaleString()}`,
       ...patterns,


### PR DESCRIPTION
close https://github.com/antfu/vscode-file-nesting-config/issues/138

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->