### PR TITLE
support .mjs and .cjs files (ES6 and commonJS)

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -300,6 +300,8 @@ const base = {
   '.gitignore': '.gitattributes, .gitmodules, .gitmessage, .mailmap, .git-blame*',
   '*.css': '$(capture).css.map, $(capture).*.css',
   '*.js': '$(capture).js.map, $(capture).*.js, $(capture)_*.js',
+  '*.mjs': '$(capture).mjs.map, $(capture).*.mjs, $(capture)_*.mjs',
+  '*.cjs': '$(capture).cjs.map, $(capture).*.cjs, $(capture)_*.cjs',
   '*.jsx': '$(capture).js, $(capture).*.jsx, $(capture)_*.js, $(capture)_*.jsx',
   '*.ts': '$(capture).js, $(capture).d.ts.map, $(capture).*.ts, $(capture)_*.js, $(capture)_*.ts',
   '*.component.ts': '$(capture).component.html, $(capture).component.spec.ts, $(capture).component.css, $(capture).component.scss, $(capture).component.sass, $(capture).component.less',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

NodeJS was supports CommonJS modules (with `require` and `module.exports`) for long time.

Now, it support also ES6 modules (with `import` and `export`, **without `babel`**). To use ES6 modules, you can set the `type: module` in your `package.json`, and/or change file extensions to `.mjs`.

Also you can do the oppsite, if you working with ES6 modules, but you need one file to be CommonJS module, you can extension it with `.cjs`.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
https://nodejs.org/api/esm.html
<!-- e.g. is there anything you'd like reviewers to focus on? -->
