### PR TITLE
Adds 'deno.lock' to denoRuntime

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -293,6 +293,7 @@ const phoenixLiveView = [
 const denoRuntime = [
   'import_map.json',
   'import-map.json',
+  'deno.lock',
   ...tsconfig,
   ...env,
 ]


### PR DESCRIPTION
### Description

The `deno.lock` file is automatically created by deno, so it should also be included in the `denoRuntime` array.
