### PR TITLE
feat: nest vite config under svelte config

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -153,7 +153,7 @@ const frameworks = {
   'vue.config.*': [],
   'nuxt.config.*': [],
   'next.config.*': ['next-env.d.ts'],
-  'svelte.config.*': ['mdsvex.config.js'],
+  'svelte.config.*': ['mdsvex.config.js', 'vite.config.*'],
   'remix.config.*': ['remix.*'],
   'artisan': ['server.php', 'webpack.mix.js'],
   'astro.config.*': [],


### PR DESCRIPTION
Currently both `vite.config.*` and `svelte.config.*` duplicates basically the same files. This is not desirable as it clutters the folder structure. My proposal is to simply nest the vite config under the svelte config. I'm not sure if my change will have that effect but please edit if that's the case.