### PR TITLE
fix: nest copying* under readme

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -227,7 +227,7 @@ const readme = [
   'codeowners',
   'contributing*',
   'contributors',
-  'copying',
+  'copying*',
   'credits',
   'governance.md',
   'history.md',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

Fixes common extensions for `copying` (e.g. `copying.md`) not being folded under `readme`.