### PR TITLE
feat: add Fable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Open your VS Code, bring up your `settings.json`, copy-n-paste the snippet below
 <!-- eslint-skip -->
 
 ```jsonc
-  // updated 2023-09-27 09:35
+  // updated 2023-10-26 13:45
   // https://github.com/antfu/vscode-file-nesting-config
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.expand": false,
@@ -48,6 +48,7 @@ Open your VS Code, bring up your `settings.json`, copy-n-paste the snippet below
     "*.cxx": "$(capture).hpp, $(capture).h, $(capture).hxx",
     "*.dart": "$(capture).freezed.dart, $(capture).g.dart",
     "*.ex": "$(capture).html.eex, $(capture).html.heex, $(capture).html.leex",
+    "*.fs": "$(capture).fs.js, $(capture).fs.jsx, $(capture).fs.ts, $(capture).fs.tsx, $(capture).fs.rs, $(capture).fs.php, $(capture).fs.dart",
     "*.go": "$(capture)_test.go",
     "*.java": "$(capture).class",
     "*.js": "$(capture).js.map, $(capture).*.js, $(capture)_*.js",

--- a/update.mjs
+++ b/update.mjs
@@ -395,6 +395,7 @@ const base = {
   '*.module.ts': '$(capture).resolver.ts, $(capture).controller.ts, $(capture).service.ts',
   '*.java': '$(capture).class',
   '.project': '.classpath',
+  '*.fs': '$(capture).fs.js, $(capture).fs.jsx, $(capture).fs.ts, $(capture).fs.tsx, $(capture).fs.rs, $(capture).fs.php, $(capture).fs.dart'
 }
 // Based on the new SvelteKit's routing system https://kit.svelte.dev/docs/routing
 const svelteKitRouting = {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add [Fable](https://fable.io/) support (to fold in-source compiled outputs from F# source files)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Added extensions `.fs.js(x)`, `.fs.ts(x)`, `.fs.rs`, `.fs.php`, `.fs.dart` based on these facts:
- Although Fable also supports Python in addition to JS, TS, Rust, PHP and Dart, the default output extension for Python is assigned as `.py`, which makes it somewhat inappropriate to be fold [(ref)](https://github.com/fable-compiler/Fable/blob/4f1b4cd6801ebcad71f79505e902dd0a0316179a/src/Fable.Cli/Util.fs#L145-L158)
- Although Fable itself doesn't emit `.fs.jsx`/`.fs.tsx` by default, many people override the default extensions with those to work with Vite (since Vite only transpiles JSX with those extensions)
