### PR TITLE
Add Fable generated source maps under `.fs` files

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -410,7 +410,7 @@ const base = {
   '*.module.ts': '$(capture).resolver.ts, $(capture).controller.ts, $(capture).service.ts',
   '*.java': '$(capture).class',
   '.project': '.classpath',
-  '*.fs': '$(capture).fs.js, $(capture).fs.jsx, $(capture).fs.ts, $(capture).fs.tsx, $(capture).fs.rs, $(capture).fs.php, $(capture).fs.dart',
+  '*.fs': '$(capture).fs.js, $(capture).fs.js.map, $(capture).fs.jsx, $(capture).fs.ts, $(capture).fs.tsx, $(capture).fs.rs, $(capture).fs.php, $(capture).fs.dart',
 }
 // Based on the new SvelteKit's routing system https://kit.svelte.dev/docs/routing
 const svelteKitRouting = {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Wen activating source maps supports for Fable, it will generate both `.fs.js` and `.fs.js.map` files.

![CleanShot 2024-01-04 at 20 50 27@2x](https://github.com/antfu/vscode-file-nesting-config/assets/4760796/5b93fcc9-1de0-44d0-b485-e28bcf24f6d4)


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
