### PR TITLE
feat: Makefile file folding

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -396,6 +396,7 @@ const base = {
   'flake.nix': 'flake.lock',
   'BUILD.bazel': '*.bzl, *.bazel, *.bazelrc, bazel.rc, .bazelignore, .bazelproject, WORKSPACE',
   'CMakeLists.txt': '*.cmake, *.cmake.in, .cmake-format.yaml, CMakePresets.json, CMakeCache.txt',
+  'Makefile': '*.mk',
   '.clang-tidy': '.clang-format, .clangd, compile_commands.json',
   '*.pubxml': '$(capture).pubxml.user',
   '*.asax': '$(capture).*.cs, $(capture).*.vb',


### PR DESCRIPTION
### Description

Addresses https://github.com/antfu/vscode-file-nesting-config/issues/195

New code folding for `Makefile`; all files with `.mk` prefix will be impacted.

### Linked Issues

#195 

### Additional context


