### PR TITLE
feat: add pylint and linters under pyprojecttoml

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -91,6 +91,7 @@ const linters = [
   'xo.config.*',
   'pyrightconfig.json',
   'biome.json',
+  '.pylintrc',
 ]
 
 const env = [
@@ -356,6 +357,7 @@ const pyprojecttoml = [
   ...setuppy,
   ...pipfile,
   ...hatchtoml,
+  ...linters,
 ]
 
 const phoenixLiveView = [


### PR DESCRIPTION
### Description

In a Python project, the `.pylintrc` file should be under the `pyproject.toml` file.


### Additional context

![image](https://github.com/antfu/vscode-file-nesting-config/assets/17686879/f9c874c1-4a2e-4d9f-a756-4e304661af16)
