### PR TITLE
feat: add solidJs Start framework & SST Ion lib

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -178,6 +178,7 @@ const tex = [
 // frameworks and their specific files
 // @keep-sorted
 const frameworks = {
+  'app.config.*':
   'artisan': ['server.php', 'webpack.mix.js'],
   'astro.config.*': [],
   'gatsby-config.*': ['gatsby-browser.*', 'gatsby-node.*', 'gatsby-ssr.*', 'gatsby-transformer.*'],
@@ -210,6 +211,7 @@ const libraries = [
   'panda.config.*',
   'postcss.config.*',
   'rspack.config.*',
+  'sst.config.*',
   'svgo.config.*',
   'tailwind.config.*',
   'uno.config.*',


### PR DESCRIPTION
### Description

- Add [Solid Start](https://docs.solidjs.com/solid-start/reference/entrypoints/app-config) config file to `frameworks`
- Add [SST Ion](https://ion.sst.dev/docs/#_top) config file to `libraries`
