### PR TITLE
feat: improve the scope of configuration file updates

### DIFF
--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -1,4 +1,5 @@
-import { workspace } from 'vscode'
+import type { WorkspaceConfiguration } from 'vscode'
+import { ConfigurationTarget, workspace } from 'vscode'
 
 export function getConfig<T = any>(key: string): T | undefined {
   return workspace
@@ -12,3 +13,40 @@ export async function setConfig(key: string, value: any, isGlobal = true) {
     .getConfiguration()
     .update(key, value, isGlobal)
 }
+
+type TargetMethod = keyof Exclude<ReturnType<WorkspaceConfiguration['inspect']>, undefined>
+
+class Config {
+  #section = 'explorer.fileNesting'
+  private configTarget: ConfigurationTarget
+  private targetMethod: TargetMethod
+
+  constructor() {
+    [this.targetMethod, this.configTarget] = this.#detectConfigTarget()
+  }
+
+  get<T = any>(key: string): T | undefined {
+    return workspace.getConfiguration(this.#section).inspect(key)?.[this.targetMethod] as T
+  }
+
+  set(key: string, value: any) {
+    return workspace.getConfiguration(this.#section).update(key, value, this.configTarget)
+  }
+
+  #detectConfigTarget(): [TargetMethod, ConfigurationTarget] {
+    const _map = new Map<TargetMethod, ConfigurationTarget>([
+      ['workspaceFolderValue', ConfigurationTarget.WorkspaceFolder],
+      ['workspaceValue', ConfigurationTarget.Workspace],
+      ['globalValue', ConfigurationTarget.Global],
+    ])
+
+    for (const [key, value] of _map) {
+      if (workspace.getConfiguration(this.#section).inspect('enabled')?.[key] === true)
+        return [key, value]
+    }
+
+    return ['globalValue', ConfigurationTarget.Global]
+  }
+}
+
+export default Config

--- a/extension/src/fetch.ts
+++ b/extension/src/fetch.ts
@@ -1,8 +1,8 @@
 import { fetch } from 'ofetch'
 import type { ExtensionContext } from 'vscode'
-import { window, workspace } from 'vscode'
+import { window } from 'vscode'
 import { FILE, MSG_PREFIX, URL_PREFIX } from './constants'
-import { getConfig } from './config'
+import Config, { getConfig } from './config'
 
 export async function fetchLatest() {
   const repo = getConfig<string>('fileNestingUpdater.upstreamRepo')
@@ -25,14 +25,14 @@ export async function fetchLatest() {
 }
 
 export async function fetchAndUpdate(ctx: ExtensionContext, prompt = true) {
-  const config = workspace.getConfiguration()
+  const fileNestingConfig = new Config()
   const patterns = await fetchLatest()
   let shouldUpdate = true
 
-  const oringalPatterns = { ...(config.get<object>('explorer.fileNesting.patterns') || {}) }
-  delete oringalPatterns['//']
+  const originalPatterns = { ...(fileNestingConfig.get<object>('patterns') || {}) }
+  delete originalPatterns['//']
   // no change
-  if (Object.keys(oringalPatterns).length > 0 && JSON.stringify(patterns) === JSON.stringify(oringalPatterns))
+  if (Object.keys(originalPatterns).length > 0 && JSON.stringify(patterns) === JSON.stringify(originalPatterns))
     return false
 
   if (prompt) {
@@ -47,16 +47,12 @@ export async function fetchAndUpdate(ctx: ExtensionContext, prompt = true) {
   }
 
   if (shouldUpdate) {
-    if (config.inspect('explorer.fileNesting.enabled')?.globalValue == null)
-      config.update('explorer.fileNesting.enabled', true, true)
-
-    if (config.inspect('explorer.fileNesting.expand')?.globalValue == null)
-      config.update('explorer.fileNesting.expand', false, true)
-
-    config.update('explorer.fileNesting.patterns', {
+    fileNestingConfig.set('enabled', true)
+    fileNestingConfig.set('expand', false)
+    fileNestingConfig.set('patterns', {
       '//': `Last update at ${new Date().toLocaleString()}`,
       ...patterns,
-    }, true)
+    })
 
     ctx.globalState.update('lastUpdate', Date.now())
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

不确定是否合理，但我仍期望 `explorer.fileNesting.enabled` 和 `explorer.fileNesting.patterns` 相邻出现。

因为：

我有一个工作区（只是阅读源码）不期望被太多配置文件打扰的情况下，我想在当前工作区配置 `explorer.fileNesting.enabled` 为 `true`,  之后扩展就只会在当前工作区进行一个更新。

我不希望他修改全局个 setting (因为它总是一大坨...

我们可以在评论中进行一些讨论，看是否有必要接受这个 PR

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
