### PR TITLE
feat: add `sentry.*.config.*` for Sentry's Nuxt module

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -49,6 +49,7 @@ const services = [
   '.gitlab*',
   '.gitpod*',
   '.sentry*',
+  'sentry.*.config.*',
   '.stackblitz*',
   '.styleci*',
   '.travis*',
@@ -216,7 +217,6 @@ const libraries = [
   'panda.config.*',
   'postcss.config.*',
   'rspack.config.*',
-  'sentry.*.config.*
   'sst.config.*',
   'svgo.config.*',
   'tailwind.config.*',

--- a/update.mjs
+++ b/update.mjs
@@ -216,6 +216,7 @@ const libraries = [
   'panda.config.*',
   'postcss.config.*',
   'rspack.config.*',
+  'sentry.*.config.*
   'sst.config.*',
   'svgo.config.*',
   'tailwind.config.*',


### PR DESCRIPTION
### Description

Sentry recently released the [@sentry/nuxt module](https://nuxt.com/modules/sentry). It introduces two files, `sentry.client.config.ts` and `sentry.server.config.ts`. This PR adds the generic `sentry.*.config.*` under the services config.  

### Linked Issues

No issues opened for this.

### Additional context

I tried to find the most appropriate place for this and thought it would be ~libraries~ services but would be grateful to know what you think.
