### PR TITLE
feat: add `.cursorrules` to services

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -44,6 +44,7 @@ const tsconfig = [
 // @keep-sorted
 const services = [
   '.circleci*',
+  '.cursorrules',
   '.firebase*',
   '.github*',
   '.gitlab*',


### PR DESCRIPTION
### Description

This PR adds [`.cursorrules`](https://docs.cursor.com/context/rules-for-ai#cursorrules) used to instruct the AI in related features in the [Cursor IDE](https://www.cursor.com) under the services config.

### Linked Issues

None at the moment.

### Additional context

I thought services would be appropriate to put this under.
