### PR TITLE
Fix double wildcard in sentry config

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -50,7 +50,7 @@ const services = [
   '.gitlab*',
   '.gitpod*',
   '.sentry*',
-  'sentry.*.config.*',
+  'sentry.*.config.ts',
   '.stackblitz*',
   '.styleci*',
   '.travis*',


### PR DESCRIPTION
### Description

Use .ts because afaict it is a new system that only seems to use that extension. https://nuxt.com/modules/sentry

### Linked Issues

https://github.com/antfu/vscode-file-nesting-config/issues/242
