### PR TITLE
feat: throw if contains multiple wildcards

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -50,7 +50,6 @@ const services = [
   '.gitlab*',
   '.gitpod*',
   '.sentry*',
-  'sentry.*.config.ts',
   '.stackblitz*',
   '.styleci*',
   '.travis*',
@@ -64,6 +63,7 @@ const services = [
   'pullapprove*',
   'release-tasks.sh',
   'renovate*',
+  'sentry.*.config.ts',
   'sonar-project.properties',
   'unlighthouse*',
   'vercel*',
@@ -552,6 +552,18 @@ const full = sortObject({
   if (!a.startsWith('*') && b.startsWith('*'))
     return -1
   return a.localeCompare(b)
+})
+
+/**
+ * Throw an error if any of the values contain multiple wildcards.
+ *
+ * See: [feat: throw if contains multiple wildcards #245](https://github.com/antfu/vscode-file-nesting-config/pull/245)
+ */
+Object.entries(full).forEach(([key, value]) => {
+  const items = value.split(',').map(i => i.trim())
+  const itemWithMultipleWildcards = items.find(i => i.split('*').length > 2)
+  if (itemWithMultipleWildcards)
+    throw new Error(`Multiple wildcards are not allowed, found in ${key}: ${itemWithMultipleWildcards}`)
 })
 
 const today = new Date().toISOString().slice(0, 16).replace('T', ' ')

--- a/update.mjs
+++ b/update.mjs
@@ -557,7 +557,7 @@ const full = sortObject({
 /**
  * Throw an error if any of the values contain multiple wildcards.
  *
- * See: [feat: throw if contains multiple wildcards #245](https://github.com/antfu/vscode-file-nesting-config/pull/245)
+ * @see https://github.com/antfu/vscode-file-nesting-config/pull/245
  */
 Object.entries(full).forEach(([key, value]) => {
   const items = value.split(',').map(i => i.trim())


### PR DESCRIPTION

### Description

Although we use ESLint to check for multiple wildcards, unexpected errors can still occur. To serve as a final safeguard and prevent critical issues from affecting extension users, I propose filtering out all multiple wildcards at this stage as well. Since the ESLint rule and CI are still in effect, we can still be notified of any incidents and address them promptly, but also prevent similar incidents from occurring in the future.

### Linked Issues

- [sentry.*.config.* in package.json Breaks explorer view for JS projects #242
](https://github.com/antfu/vscode-file-nesting-config/issues/242)
- [feat: add linter to guard usage](https://github.com/antfu/vscode-file-nesting-config/commit/324d02e59504a6a8ea3866fc1cf4b14f830aa34c)
- [*.knip.* causing VSCode file explorer does not display files #186
](https://github.com/antfu/vscode-file-nesting-config/issues/186)
