### PR TITLE
feat: add `$(capture).wasm`

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -462,6 +462,7 @@ const base = {
   '*.tsx': '$(capture).ts, $(capture).*.tsx, $(capture)_*.ts, $(capture)_*.tsx, $(capture).module.css, $(capture).less, $(capture).module.less, $(capture).module.less.d.ts, $(capture).scss, $(capture).module.scss, $(capture).module.scss.d.ts, $(capture).css.ts',
   '*.vue': '$(capture).*.ts, $(capture).*.js, $(capture).story.vue',
   '*.w': '$(capture).*.w, I$(capture).w',
+  '*.wat': '$(capture).wasm',
   '*.xaml': '$(capture).xaml.cs',
   'ansible.cfg': 'ansible.cfg, .ansible-lint, requirements.yml',
   'build-wrapper.log': 'build-wrapper*.log, build-wrapper-dump*.json, build-wrapper-win*.exe, build-wrapper-linux*, build-wrapper-macosx*',
@@ -474,7 +475,6 @@ const base = {
   'I*.cs': '$(capture).cs',
   'Makefile': '*.mk',
   'shims.d.ts': '*.d.ts',
-  '*.wat': '$(capture).wasm',
 }
 // Based on the new SvelteKit's routing system https://kit.svelte.dev/docs/routing
 const svelteKitRouting = {

--- a/update.mjs
+++ b/update.mjs
@@ -474,6 +474,7 @@ const base = {
   'I*.cs': '$(capture).cs',
   'Makefile': '*.mk',
   'shims.d.ts': '*.d.ts',
+  '*.wat': '$(capture).wasm',
 }
 // Based on the new SvelteKit's routing system https://kit.svelte.dev/docs/routing
 const svelteKitRouting = {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds WebAssembly text support with a capturing group for the compiled WebAssembly binary. 

### Linked Issues


### Additional context

This is better than if it were reversed since not all `.wasm` files have a corresponding `.wat` file, but all `.wat` files are compiled into a corresponding `.wasm` file, conventionally with the same filename and location.
