### PR TITLE
feat: add more extension support for wrangler config file

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -70,7 +70,7 @@ const services = [
   'sonar-project.properties',
   'unlighthouse*',
   'vercel*',
-  'wrangler.toml',
+  'wrangler.*',
 ]
 
 // @keep-sorted


### PR DESCRIPTION
### Description

Cloudflare's Wrangler now [supports](https://developers.cloudflare.com/workers/wrangler/configuration/) `wrangler.json` and `wrangler.jsonc` files, other than the usual `wrangler.toml`. This PR changes the pattern for wrangler to accept any file extension.

### Linked Issues

None.

### Additional context

None.
