### PR TITLE
Fix `Cargo.lock` casing, add `Cargo.bazel.lock` and `insta.yaml`

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -304,6 +304,7 @@ readme = addLowerCaseVariants(readme)
 const cargo = [
   '.clippy.toml',
   '.rustfmt.toml',
+  'Cargo.bazel.lock',
   'Cargo.lock',
   'clippy.toml',
   'cross.toml',

--- a/update.mjs
+++ b/update.mjs
@@ -304,7 +304,7 @@ readme = addLowerCaseVariants(readme)
 const cargo = [
   '.clippy.toml',
   '.rustfmt.toml',
-  'Cargo.bazel.lock',
+  'Cargo.Bazel.lock',
   'Cargo.lock',
   'clippy.toml',
   'cross.toml',

--- a/update.mjs
+++ b/update.mjs
@@ -304,9 +304,10 @@ readme = addLowerCaseVariants(readme)
 const cargo = [
   '.clippy.toml',
   '.rustfmt.toml',
-  'cargo.lock',
+  'Cargo.lock',
   'clippy.toml',
   'cross.toml',
+  'insta.yaml',
   'rust-toolchain.toml',
   'rustfmt.toml',
 ]


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- The names need to be case sensitive so the `Cargo.lock` file (uppercase C by convention) wasn't getting matched with the cargo files.
- `Cargo.Bazel.lock` is a file that may be generated as part of [bazel's `rules_rust`](https://bazelbuild.github.io/rules_rust/crate_universe.html) -- but it is inherently linked to the rust setup, hence I added it to `Cargo.toml` here rather than `BUILD.bazel`
- `insta.yaml` is a config file for insta (https://insta.rs/) a snapshot testing library for rust.

### Linked Issues

N/A

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
