### PR TITLE
feat: add .windsurfrules to services

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -59,6 +59,7 @@ const services = [
   '.stackblitz*',
   '.styleci*',
   '.travis*',
+  '.windsurfrules',
   'appveyor*',
   'azure-pipelines*',
   'colada.options.ts',


### PR DESCRIPTION
### Description

This PR adds [.windsurfrules](https://docs.codeium.com/windsurf/memories#windsurfrules) used to instruct the AI in related features in the [Windsurf Editor](https://codeium.com/windsurf) under the services config.

### Linked Issues

_none_

### Additional context

I select the `services` section according to the existing `.cursorrules`.
