### PR TITLE
feat: add `*.cshtml.css` under `*.cshtml`

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -459,7 +459,7 @@ const base = {
   '*.component.ts': '$(capture).component.html, $(capture).component.spec.ts, $(capture).component.css, $(capture).component.scss, $(capture).component.sass, $(capture).component.less',
   '*.cpp': '$(capture).hpp, $(capture).h, $(capture).hxx, $(capture).hh',
   '*.cs': '$(capture).*.cs',
-  '*.cshtml': '$(capture).cshtml.cs',
+  '*.cshtml': '$(capture).cshtml.cs, $(capture).cshtml.css',
   '*.css': '$(capture).css.map, $(capture).*.css',
   '*.cxx': '$(capture).hpp, $(capture).h, $(capture).hxx, $(capture).hh',
   '*.dart': '$(capture).freezed.dart, $(capture).g.dart',


### PR DESCRIPTION
### Description

At Visual Studio 2022, scoped CSS for `*.cshtml` is nested under it along with `*.cshtml.cs`:
![image](https://github.com/user-attachments/assets/3ec7d128-d178-4031-bcad-cd93a15a6ad0)

However, with the current config at VS Code, only `*.cshtml.cs` is nested:
![image](https://github.com/user-attachments/assets/880ed2c0-08f9-4d42-a9b6-7afd1ea96b18)

This PR aims to make it consistent with Visual Studio's nesting:
![image](https://github.com/user-attachments/assets/76332a9b-e4c0-40ec-aad1-f1cc5f57d8a4)

### Linked Issues

N/A

### Additional context

N/A
