### PR TITLE
feat: add taze.config.* to workspaces array

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -156,6 +156,7 @@ const workspaces = [
   'release-please*.json',
   'release.config.*',
   'simple-git-hooks*',
+  'taze.config.*',
   'turbo*',
   'workspace.json',
   'yarn*',


### PR DESCRIPTION
### Description

Extends the workspaces array to include `taze.config.*` files.

### Linked Issues

_none_

### Additional context

See: https://github.com/antfu-collective/taze/ for more information about the tool.