### PR TITLE
fix: Replace Quasar glob pattern in update.mjs

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -219,7 +219,7 @@ const frameworks = {
   'gatsby-config.*': ['gatsby-browser.*', 'gatsby-node.*', 'gatsby-ssr.*', 'gatsby-transformer.*'],
   'next.config.*': ['next-env.d.ts', 'next-i18next.config.*'],
   'nuxt.config.*': ['.nuxtignore', '.nuxtrc'],
-  'quasar.conf{ig}.{js,ts}': ['quasar.extensions.json'],
+  'quasar.conf*': ['quasar.extensions.json'],
   'remix.config.*': ['remix.*'],
   'svelte.config.*': ['mdsvex.config.js', 'vite.config.*', 'houdini.config.*'],
   'vite.config.*': [],


### PR DESCRIPTION
This pr removes the Quasar glob pattern which VSCode File Nesting surprisingly doesn't support, and replaces it with a working pattern `quasar.conf*`. 

Fixes: https://github.com/antfu/vscode-file-nesting-config/pull/318

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [X] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

### Linked Issues

fixes #<number>

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
