### PR TITLE
feat: add `oxfmt.config.*`

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -114,6 +114,7 @@ const linters = [
   'dprint.json*',
   'eslint*',
   'lint-staged*',
+  'oxfmt.config.*',
   'oxlint.config.*',
   'phpcs.xml',
   'prettier*',


### PR DESCRIPTION
## Description

Extends the workspaces array to include `oxfmt.config.*` files.

## Linked Issues

none

## Additional context

See https://github.com/oxc-project/oxc/pull/20135 for more information about the tool.