### PR TITLE
feat: add packages.lock.json and *.fsproj to dotnet project nesting

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -385,6 +385,7 @@ const dotnetProject = [
   '*.config',
   'appsettings.*',
   'bundleconfig.json',
+  'packages.lock.json',
 ]
 
 const pubspecYAML = [
@@ -627,6 +628,7 @@ const full = sortObject({
   'go.mod': stringify(gofile),
   'composer.json': stringify(composer),
   '*.csproj': stringify(dotnetProject),
+  '*.fsproj': stringify(dotnetProject),
   '*.vbproj': stringify(dotnetProject),
   'mix.exs': stringify(elixir),
   'pyproject.toml': stringify(pyprojecttoml),


### PR DESCRIPTION
Closes #192

### Linked issue

Resolves #192

### Context

NuGet's `RestorePackagesWithLockFile` generates `packages.lock.json` alongside project files, but it's not nested in the explorer. Also, `*.fsproj` (F# projects) was missing from the dotnet project nesting rules.

### Description

- Added `packages.lock.json` to the `dotnetProject` array so it nests under `*.csproj`, `*.vbproj`, and `*.fsproj`
- Added `*.fsproj` entry using the same `dotnetProject` nesting rules