### PR TITLE
feat: add justfile nesting support

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -385,6 +385,7 @@ const dotnetProject = [
   '*.config',
   'appsettings.*',
   'bundleconfig.json',
+  'packages.lock.json',
 ]
 
 const pubspecYAML = [
@@ -627,6 +628,7 @@ const full = sortObject({
   'go.mod': stringify(gofile),
   'composer.json': stringify(composer),
   '*.csproj': stringify(dotnetProject),
+  '*.fsproj': stringify(dotnetProject),
   '*.vbproj': stringify(dotnetProject),
   'mix.exs': stringify(elixir),
   'pyproject.toml': stringify(pyprojecttoml),

--- a/update.mjs
+++ b/update.mjs
@@ -557,6 +557,7 @@ const base = {
   'go.mod': 'go.sum',
   'go.work': 'go.work.sum',
   'I*.cs': '$(capture).cs',
+  'justfile': '*.just, .justfile',
   'Makefile': '*.mk',
   'pom.xml': 'mvnw*',
   'shims.d.ts': '*.d.ts',


### PR DESCRIPTION
Closes #293

### Linked issue

Resolves #293

### Context

`just` is a popular command runner (alternative to Make). Its config files
(`*.just`, `.justfile`) are not currently nested in the explorer.

### Description

- Added `justfile` entry to nest `*.just` and `.justfile` under it