### PR TITLE
feat: add .vsls.json to package.json nesting

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -385,6 +385,7 @@ const dotnetProject = [
   '*.config',
   'appsettings.*',
   'bundleconfig.json',
+  'packages.lock.json',
 ]
 
 const pubspecYAML = [
@@ -627,6 +628,7 @@ const full = sortObject({
   'go.mod': stringify(gofile),
   'composer.json': stringify(composer),
   '*.csproj': stringify(dotnetProject),
+  '*.fsproj': stringify(dotnetProject),
   '*.vbproj': stringify(dotnetProject),
   'mix.exs': stringify(elixir),
   'pyproject.toml': stringify(pyprojecttoml),

--- a/update.mjs
+++ b/update.mjs
@@ -250,7 +250,7 @@ const frameworks = {
   'astro.config.*': [],
   'gatsby-config.*': ['gatsby-browser.*', 'gatsby-node.*', 'gatsby-ssr.*', 'gatsby-transformer.*'],
   'next.config.*': ['next-env.d.ts', 'next-i18next.config.*'],
-  'nuxt.config.*': ['.nuxtignore', '.nuxtrc'],
+  'nuxt.config.*': ['.nuxtignore', '.nuxtrc', 'nuxt.schema.*'],
   'quasar.conf*': ['quasar.extensions.json'],
   'remix.config.*': ['remix.*'],
   'svelte.config.*': ['mdsvex.config.js', 'vite.config.*', 'houdini.config.*'],

--- a/update.mjs
+++ b/update.mjs
@@ -557,6 +557,7 @@ const base = {
   'go.mod': 'go.sum',
   'go.work': 'go.work.sum',
   'I*.cs': '$(capture).cs',
+  'justfile': '*.just, .justfile',
   'Makefile': '*.mk',
   'pom.xml': 'mvnw*',
   'shims.d.ts': '*.d.ts',

--- a/update.mjs
+++ b/update.mjs
@@ -146,6 +146,7 @@ const workspaces = [
   '.simple-git-hooks*',
   '.tazerc*',
   '.tool-versions',
+  '.vsls.json',
   '.yarnrc*',
   '*.code-workspace',
   'bower.json',
@@ -405,6 +406,7 @@ const elixir = [
   '.dialyzer_ignore.exs',
   '.iex.exs',
   '.tool-versions',
+
 ]
 
 const pythonConfigs = [


### PR DESCRIPTION
Closes #254

### Linked issue

Resolves #254

### Context

`.vsls.json` is the config file for VS Code Live Share, but it's not nested in the explorer.

### Description

- Added `.vsls.json` to the `workspaces` array so it nests under `package.json`