### PR TITLE
fix(extension): stabilize update marker

### DIFF
--- a/extension/src/fetch.ts
+++ b/extension/src/fetch.ts
@@ -4,12 +4,15 @@ import { window, workspace } from 'vscode'
 import { getConfig } from './config'
 import { FILE, MSG_PREFIX, URL_PREFIX } from './constants'
 
+const UPDATE_MARKER_FALLBACK = 'Last update from upstream'
+
 export async function fetchLatest() {
   const repo = getConfig<string>('fileNestingUpdater.upstreamRepo')
   const branch = getConfig<string>('fileNestingUpdater.upstreamBranch')
   const url = `${URL_PREFIX}/${repo}@${branch}/${FILE}`
   const md = await fetch(url).then(r => r.text())
   const content = (md.match(/```jsonc([\s\S]*?)```/) || [])[1] || ''
+  const updated = content.match(/^\s*\/\/ updated (.+)$/m)?.[1]?.trim()
 
   const json = `{${
     content
@@ -21,12 +24,15 @@ export async function fetchLatest() {
   }}`
 
   const config = JSON.parse(json) || {}
-  return config['explorer.fileNesting.patterns']
+  return {
+    patterns: config['explorer.fileNesting.patterns'],
+    updated,
+  }
 }
 
 export async function fetchAndUpdate(ctx: ExtensionContext, prompt = true) {
   const config = workspace.getConfiguration()
-  const patterns = await fetchLatest()
+  const { patterns, updated } = await fetchLatest()
   let shouldUpdate = true
 
   const oringalPatterns = { ...(config.get<object>('explorer.fileNesting.patterns') || {}) }
@@ -54,7 +60,9 @@ export async function fetchAndUpdate(ctx: ExtensionContext, prompt = true) {
       config.update('explorer.fileNesting.expand', false, true)
 
     config.update('explorer.fileNesting.patterns', {
-      '//': `Last update at ${new Date().toLocaleString()}`,
+      '//': updated
+        ? `Last update from upstream at ${updated} UTC`
+        : UPDATE_MARKER_FALLBACK,
       ...patterns,
     }, true)
 

--- a/extension/src/fetch.ts
+++ b/extension/src/fetch.ts
@@ -61,7 +61,7 @@ export async function fetchAndUpdate(ctx: ExtensionContext, prompt = true) {
 
     config.update('explorer.fileNesting.patterns', {
       '//': updated
-        ? `Last update from upstream at ${updated} UTC`
+        ? `Last update at ${updated} UTC`
         : UPDATE_MARKER_FALLBACK,
       ...patterns,
     }, true)


### PR DESCRIPTION
### Description

Use the timestamp embedded in the upstream README config block for the generated `explorer.fileNesting.patterns["//"]` marker instead of formatting the local update time with `toLocaleString()`.

Before this change, the extension rewrote the marker with each machine's local locale, for example:

```jsonc
"//": "Last update at 2026/4/23 22:05:30"
"//": "Last update at 4/27/2026, 4:01:10 PM"
```

When VS Code/Cursor settings are synced across Windows and macOS (via Settings Sync, dotfiles, or a git-tracked `settings.json`), the same upstream file-nesting config can therefore create platform-specific churn and merge conflicts even when the actual nesting patterns are identical.

This keeps the previous marker shape (`Last update at ...`) but makes the value deterministic by reusing the upstream README timestamp, for example:

```jsonc
"//": "Last update at 2026-04-20 00:47 UTC"
```

The marker is not used for file-nesting parsing or config comparison: the extension already removes the `"//"` marker before comparing local patterns, while the upstream README parser strips JSONC comment lines before `JSON.parse`.

### Linked Issues

N/A. No exact existing issue/PR was found for the locale-specific update marker; related updater behavior discussions include #127 and #218.

### Verification

- `git diff --check`
- Parsed the current README config block with Node to verify the upstream timestamp and JSON extraction still work.